### PR TITLE
Update klite.embd to allow models to omit semicolons, as they always do

### DIFF
--- a/klite.embd
+++ b/klite.embd
@@ -12909,7 +12909,7 @@ Current version indicated by LITEVER below.
 		{
 			let st = get_instruct_starttag(true);
 			let et = get_instruct_endtag(true);
-			seqs = [st, et];
+			seqs = [st, et, st.replace(/:/g, '\n'), et.replace(/:/g, '\n')];
 			if(localsettings.inject_chatnames_instruct)
 			{
 				if(localsettings.chatname!="")


### PR DESCRIPTION
Models like aya-expanse-32b and internlm2_5-20b-chat can miss the semicolon when generate, so it would be very helpful if the `stop_sequence` configuration can just accept the form that without semicolon. On second thought, maybe including the semicolon-free format in the `stop_sequence` configuration can just be an opt-out option.